### PR TITLE
Fix spelling.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   sudo: yes
   apt: name=redis-server state=latest
 
-- name: Setup redus
+- name: Setup Redis
   sudo: yes
   lineinfile: >
     dest=/etc/redis/redis.conf


### PR DESCRIPTION
Spelling: `redus` -> `Redis`.
